### PR TITLE
Use dtostrf() for AVR only

### DIFF
--- a/ostream_helpers
+++ b/ostream_helpers
@@ -245,10 +245,13 @@ namespace std{
 		{
 			char buffer[32];
 			int length;
-			
-			//length = snprintf(buffer, 32, "%*.*f",static_cast<int>(stream.width()),static_cast<int>(stream.precision()), f);
+
+#ifdef __AVR__
 			length = strlen(dtostrf(f, static_cast<int>(stream.width()), static_cast<int>(stream.precision()), buffer));
-					
+#else
+			length = snprintf(buffer, 32, "%*.*f",static_cast<int>(stream.width()),static_cast<int>(stream.precision()), f);
+#endif
+
 			stream.printout(buffer, length);
 			if(stream.flags() & ios_base::unitbuf){
 				stream.flush();


### PR DESCRIPTION
Otherwise, the library cannot be used with esp8266. This pattern (`#ifdef
__AVR__`) can also be found at other places in the code.

I'm sending this PR to your repo, as the platformio library currently points to this branch. But maybe you want to merge your changes back to the orginal repo? Or maybe merge your patch-1 branch into your fork's master, so people can send their PRs to you. At the moment, the state and governance of StandardCplusplus is kind of confusing.
